### PR TITLE
Add Ludo game mode selection

### DIFF
--- a/app/(ludo)/cpu.js
+++ b/app/(ludo)/cpu.js
@@ -1,0 +1,22 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function CpuLudo() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>CPU mode coming soon...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1A1A',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: 'white',
+    fontSize: 18,
+  },
+});

--- a/app/(ludo)/index.js
+++ b/app/(ludo)/index.js
@@ -1,11 +1,29 @@
-// app/ludo/index.js
-import { View, StyleSheet } from 'react-native';
-import LudoBoard from './components/LudoBoard';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
 
-export default function LudoScreen() {
+export default function LudoModeScreen() {
+  const router = useRouter();
   return (
     <View style={styles.container}>
-      <LudoBoard />
+      <Text style={styles.title}>Ludo King</Text>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => router.push('offline')}
+      >
+        <Text style={styles.buttonText}>Offline Play</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => router.push('cpu')}
+      >
+        <Text style={styles.buttonText}>Play vs CPU</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => router.push('online')}
+      >
+        <Text style={styles.buttonText}>Online Play</Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -16,5 +34,21 @@ const styles = StyleSheet.create({
     backgroundColor: '#1A1A1A',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 32,
+    marginBottom: 40,
+  },
+  button: {
+    backgroundColor: '#8e2de2',
+    paddingHorizontal: 40,
+    paddingVertical: 15,
+    borderRadius: 10,
+    marginVertical: 10,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 18,
   },
 });

--- a/app/(ludo)/offline.js
+++ b/app/(ludo)/offline.js
@@ -1,0 +1,19 @@
+import { View, StyleSheet } from 'react-native';
+import LudoBoard from './components/LudoBoard';
+
+export default function OfflineLudo() {
+  return (
+    <View style={styles.container}>
+      <LudoBoard />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1A1A',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/app/(ludo)/online.js
+++ b/app/(ludo)/online.js
@@ -1,0 +1,22 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function OnlineLudo() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Online mode coming soon...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1A1A',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: 'white',
+    fontSize: 18,
+  },
+});


### PR DESCRIPTION
## Summary
- switch Ludo entry screen to choose play mode
- add offline mode screen with existing board
- scaffold CPU and online mode screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c060d34f483298ea13b56c4e87582