### PR TITLE
Improve offline Ludo screen

### DIFF
--- a/app/(ludo)/components/LudoBoard.js
+++ b/app/(ludo)/components/LudoBoard.js
@@ -1770,7 +1770,9 @@ export default class LudoBoard extends React.Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'khaki',
+    backgroundColor: '#f8f8f8',
+    padding: 10,
+    borderRadius: 8,
   },
   red : {
     backgroundColor : "#fa9daa"

--- a/app/(ludo)/offline.js
+++ b/app/(ludo)/offline.js
@@ -1,18 +1,34 @@
-import { View, StyleSheet } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet, Animated } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import LudoBoard from './components/LudoBoard';
 
 export default function OfflineLudo() {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 500,
+      useNativeDriver: true,
+    }).start();
+  }, []);
+
   return (
-    <View style={styles.container}>
-      <LudoBoard />
-    </View>
+    <LinearGradient
+      colors={['#3a1c71', '#d76d77', '#ffaf7b']}
+      style={styles.container}
+    >
+      <Animated.View style={{ opacity: fadeAnim }}>
+        <LudoBoard />
+      </Animated.View>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1A1A1A',
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
## Summary
- polish offline ludo screen with a gradient background and fade-in effect
- tweak ludo board container styling

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c0a50ddb88329aa56a2a037f1b027