### PR TITLE
Fix Expo BVLinearGradient error

### DIFF
--- a/app/(ludo)/components/Dice.tsx
+++ b/app/(ludo)/components/Dice.tsx
@@ -1,6 +1,6 @@
 import { Animated, Easing, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import React, { memo, useEffect, useRef, useState } from 'react'
-import { LinearGradient } from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import { BackgroundImage } from '../helpers/GetIcon';
 import LottieView from 'lottie-react-native';
 import { ANIMATATIONS } from '../assets/animation';

--- a/app/(ludo)/components/GradientButton.tsx
+++ b/app/(ludo)/components/GradientButton.tsx
@@ -7,7 +7,7 @@ import {
     UsersIcon,
     HomeIcon,
 } from 'react-native-heroicons/solid';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import { RFValue } from 'react-native-responsive-fontsize';
 import { playSound } from '../helpers/SoundUtils';
 import { COLORS } from '../constants/colors';

--- a/app/(ludo)/components/MenuModal.tsx
+++ b/app/(ludo)/components/MenuModal.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Modal from 'react-native-modal';
 import GradientButton from './GradientButton';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useAppDispatch } from '../hooks/useAppStore';
 import { announceWinner, resetGame } from '../redux/reducers/gameSlice';
 import { playSound } from '../helpers/SoundUtils';

--- a/app/(ludo)/components/WinnerModal.tsx
+++ b/app/(ludo)/components/WinnerModal.tsx
@@ -3,7 +3,7 @@ import React, { memo, useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Modal from 'react-native-modal';
 import { useDispatch } from 'react-redux';
-import LinearGradient from 'react-native-linear-gradient';
+import { LinearGradient } from 'expo-linear-gradient';
 import LottieView from 'lottie-react-native';
 import GradientButton from './GradientButton';
 import Pile from './Pile';

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react-native-first-launch": "^1.0.0",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-heroicons": "^4.0.0",
-        "react-native-linear-gradient": "^2.8.3",
         "react-native-mmkv": "^2.12.2",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-reanimated": "~3.17.4",
@@ -12613,16 +12612,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
       "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-linear-gradient": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.8.3.tgz",
-      "integrity": "sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-native-first-launch": "^1.0.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-heroicons": "^4.0.0",
-    "react-native-linear-gradient": "^2.8.3",
     "react-native-mmkv": "^2.12.2",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-reanimated": "~3.17.4",


### PR DESCRIPTION
## Summary
- use `expo-linear-gradient` instead of `react-native-linear-gradient`
- remove unused `react-native-linear-gradient` dependency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68833f6b53208329bb70fd3f6149118d