### PR TITLE
Fix Ludo piece capture logic

### DIFF
--- a/app/(ludo)/components/Pile.tsx
+++ b/app/(ludo)/components/Pile.tsx
@@ -29,7 +29,7 @@ const Pile: React.FC<PileProp> = ({ color, player, cell, pieceId, onPress }) => 
 
     const isForwardable = useCallback(() => {
         const piece = playerPieces?.find((item: PLAYER_PIECE) => item.id === pieceId);
-        return piece && ((piece.travelCount + diceNo) <= 7);
+        return piece && ((piece.travelCount + diceNo) <= 57);
     }, [playerPieces, diceNo, pieceId]);
 
     useEffect(() => {

--- a/app/(ludo)/redux/reducers/gameActions.ts
+++ b/app/(ludo)/redux/reducers/gameActions.ts
@@ -72,8 +72,8 @@ export const handleForwardThunk = (playerNo: number, id: string, pos: number) =>
 
         if (
             areDifferentIds &&
-            !safeSpots.includes(finalPath[0].pos) &&
-            !starSpots.includes(finalPath[0].pos)
+            !safeSpots.includes(finalPath) &&
+            !starSpots.includes(finalPath)
         ) {
             const enemyPiece = finalPlot.find((p) => p.id[0] !== id[0]);
             const enemyId = enemyPiece.id[0];
@@ -91,7 +91,7 @@ export const handleForwardThunk = (playerNo: number, id: string, pos: number) =>
                     travelCount: 0
                 }))
 
-                await delay(0.4)
+                await delay(400)
                 i--;
                 if (i === 0) {
                     i = 52;


### PR DESCRIPTION
## Summary
- fix `isForwardable` check so pieces can move up to 57 spaces
- correct enemy capture logic when landing on opponent piece
- use realistic delay value when sending enemy piece home

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules / expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6883465ac4f48329a751f94265a218cc