### PR TITLE
Fix turn order after yellow piece moves out

### DIFF
--- a/app/(ludo)/redux/reducers/gameActions.ts
+++ b/app/(ludo)/redux/reducers/gameActions.ts
@@ -128,7 +128,7 @@ export const handleForwardThunk = (playerNo: number, id: string, pos: number) =>
             }
         } else {
             let chancePlayer: number = playerNo + 1;
-            if (chancePlayer >= 4) {
+            if (chancePlayer > 4) {
                 chancePlayer = 1;
             }
             dispatch(updatePlayerChance({ chancePlayer }))


### PR DESCRIPTION
## Summary
- correct wraparound condition for next player in Ludo game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884af480cb4832980ce710261ea05ef