### PR TITLE
Fix incorrect transform prop causing error

### DIFF
--- a/app/(ludo)/components/FourTriangle.tsx
+++ b/app/(ludo)/components/FourTriangle.tsx
@@ -138,7 +138,7 @@ const FourTriangle: React.FC<FourTriangleProps> = ({ player1, player2, player3, 
                     right: data.right,
                 }}
                 pieceColor={data.pieceColor}
-                translate={data.pieceColor}
+                translate={data.translate}
             />
         )
     }, [playersData])


### PR DESCRIPTION
## Summary
- fix transform prop name when rendering player pieces in FourTriangle component

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6884b5f8c78c8329b56063886cc1c63f