### PR TITLE
Fix dice lock when rolling a 6 without pieces

### DIFF
--- a/app/(ludo)/components/Dice.tsx
+++ b/app/(ludo)/components/Dice.tsx
@@ -68,9 +68,10 @@ const Dice: React.FC<DiceProps> = ({ color, rotate, player, data }) => {
         setDiceRolling(false);
         const isAnyPieceAlive = data?.findIndex((e) => e.pos !== 0 && e.pos !== 57);
         const isAnyPieceLocked = data?.findIndex((e) => e.pos !== 0);
+        const isAnyPieceAtStart = data?.findIndex((e) => e.pos === 0);
 
         if (isAnyPieceAlive == -1) {
-            if (diceNumber === 6) {
+            if (diceNumber === 6 && isAnyPieceAtStart !== -1) {
                 dispatch(enablePileSelection({ playerNo: player }))
             } else {
                 let chancePlayer = player + 1;


### PR DESCRIPTION
## Summary
- avoid forcing pile selection when no pieces are in the pocket

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884bd9830448329abc3e5739f0af8ce